### PR TITLE
Fix bug "object 'ID' not found" 

### DIFF
--- a/R/roastGO.R
+++ b/R/roastGO.R
@@ -166,9 +166,8 @@ roastGO <- function(data,
    if (Paired == TRUE){
       suppressWarnings(
          suppressMessages(
-            log2FCs <- dplyr::mutate(limma_tab,
-                                     ID = ID) %>%  
-               dplyr::select(ID, log2FC = eval(dim(.)[2]-5)) %>% 
+            log2FCs <- dplyr::mutate(limma_tab, ID = rownames(limma_tab)) %>%  
+               dplyr::select(ID, log2FC = eval(dim(.)[2]-6)) %>% 
                dplyr::left_join(., genesinterm, by = "ID")  %>%
                dplyr::left_join(., goterm_n_iddf, by = c("GOID", "GOTERM")) %>%
                dplyr::rename(CategoryID = GOID, CategoryTerm = GOTERM) %>%
@@ -178,8 +177,7 @@ roastGO <- function(data,
    } else if (Paired == FALSE){
       suppressWarnings(
          suppressMessages(
-            log2FCs <- dplyr::mutate(limma_tab,
-                                     ID = ID) %>%  
+            log2FCs <- dplyr::mutate(limma_tab, ID = rownames(limma_tab)) %>%  
                dplyr::select(ID, log2FC = logFC) %>% 
                dplyr::left_join(., genesinterm, by = "ID")  %>%
                dplyr::left_join(., goterm_n_iddf, by = c("GOID", "GOTERM")) %>%

--- a/enrichRoast_script_limma_input_v0.1.R
+++ b/enrichRoast_script_limma_input_v0.1.R
@@ -135,7 +135,7 @@ specific_category = "NABA"  # i.e. "NABA"... A string that can be used to subset
 ### Install required packages if necessary
 
 packages <- c("dplyr", "here", "stringr", "tidyr", "ggplot2", "qdapTools", "reshape2",
-              "backports", "statmod", "forcats")
+              "backports", "statmod", "forcats", "ggridges")
 
 biopackgs <- c(orgDB, "limma", "reactome.db", "clusterProfiler",
                "msigdbr", "KEGGREST", "AnnotationDbi", "GO.db")


### PR DESCRIPTION
Error:
```
Error (roastGO.R#167): Problem with `mutate()` input `ID`.
x object 'ID' not found
i Input `ID` is `ID`.
```
Input data had an ID column:
![grafik](https://user-images.githubusercontent.com/34959927/102992265-34f77c00-451b-11eb-90db-e609f84f0f5b.png)

The ID column is sliced out (`roastGO.R Line: 40`) and IDs are converted as row names (`roastGO.R Line: 45`).

There was no object to get the `ID` column, which was fixed by adding the IDs by the rownames of the table `limma_tab` itself. Since one additional column was added in `limma_tab` the column ID evaluation needs to be changed (`5` -> `6`).

There was a missing dependency, which was added in the `packages` vector.